### PR TITLE
Add new max width to content and fix the ad text flow

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -25,9 +25,9 @@ const about = () => {
         </div>
       </div>
       <div className='about-section py-12 lg:py-28 bg-gradient-to-br from-[#C89A77] via-[#8F553F] to-[#8f563fd9]'>
-        <div className='max-w-[1400px] md:flex md:justify-between gap-10 m-auto px-6 text-white'>
+        <div className='max-w-[1200px] md:flex md:justify-between gap-10 m-auto px-6 text-white'>
           <div className='title md:w-[25%]'>
-            <h2 className='text-4xl font-extrabold pb-4 text-center md:text-5xl md:text-end lg:text-6xl'>
+            <h2 className='font-bold pb-4 text-center text-3xl md:text-4xl lg:text-5xl'>
               About Us
             </h2>
           </div>
@@ -45,10 +45,10 @@ const about = () => {
           </div>
         </div>
       </div>
-      <div className='story-section max-w-[1400px] px-6 py-12 md:py-24 tracking-[.15em] mx-auto'>
+      <div className='story-section max-w-[1200px] px-6 py-12 md:py-24 tracking-[.15em] mx-auto'>
         <div className='lg:flex lg:justify-between md:gap-10 mx-auto text-center lg:text-start'>
           <div className='title-desc w-full pb-4 max-w-[500px] lg:max-w-[600px] m-auto'>
-            <h2 className='text-3xl md:text-3xl lg:text-5xl font-bold pb-4 md:leading-[4rem]'>
+            <h2 className='text-3xl md:text-4xl lg:text-5xl font-bold pb-4 md:leading-[4rem]'>
               The Person Behind The Moment
             </h2>
             <p className='desc md:text-xl tracking-wider'>
@@ -73,15 +73,15 @@ const about = () => {
           </div>
         </div>
       </div>
-      <div className='max-w-[1400px] mx-auto flex items-center px-6 py-12'>
+      <div className='max-w-[1200px] mx-auto flex items-center px-6 py-12'>
         <hr className='flex-grow h-[4px] bg-gray-700' />
         <span className='text-3xl md:text-4xl font-extrabold uppercase px-4 text-center'>
           <Image src={Logo} width={300} height={300} alt='Logo Image' />
         </span>
         <hr className='flex-grow h-[4px] bg-gray-700' />
       </div>
-      <div className='images-section max-w-[1400px] px-6  md:py-24 m-auto'>
-        <h2 className='text-3xl md:text-3xl lg:text-5xl font-bold pb-12 md:leading-[4rem] text-center'>
+      <div className='images-section max-w-[1200px] px-6  md:py-24 m-auto'>
+        <h2 className='text-3xl md:text-4xl lg:text-5xl font-bold pb-12 md:leading-[4rem] text-center'>
           Your <span className='text-[#B4794D]'>Memento</span> Starts With Us
         </h2>
         <div className='images grid grid-cols-2 md:grid-cols-4 gap-8 w-full'>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,10 +51,10 @@ export default function Home() {
           </div>
         </div>
       </div>
-      <div className='about max-w-[1400px] mx-auto px-6'>
+      <div className='about max-w-[1200px] mx-auto px-6'>
         <div className='about-logo md:mx-auto flex flex-col md:flex-row md:justify-between md:items-center md:gap-8'>
           <div className='content mx-auto max-w-[500px] md:md:min-w-[300px] md:max-w-[600px] py-12 md:py-24 text-center order-2'>
-            <h2 className='text-3xl md:text-3xl lg:text-5xl font-bold'>
+            <h2 className='text-3xl md:text-4xl lg:text-5xl font-bold'>
               The Perfect Booth <br />
               For Your Mementos
             </h2>
@@ -113,7 +113,7 @@ export default function Home() {
           </div>
         </div>
       </div>
-      <div className='products-container max-w-[1400px] py-12 md:py-24 px-6 w-full md:mx-auto'>
+      <div className='products-container max-w-[1200px] py-12 md:py-24 px-6 w-full md:mx-auto'>
         <div className='unlimited-photos md:mx-auto md:flex md:justify-between md:items-center md:gap-4'>
           <div className='image order-2 w-full pb-4 md:pb-0'>
             <Image

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -43,10 +43,10 @@ const products = () => {
       <div className='call to action pb-12 md:pb-36'>
         <CTA />
       </div>
-      <div className='feature-container max-w-[1400px] tracking-[.15em] mx-auto pb-12 md:pb-36'>
+      <div className='feature-container max-w-[1200px] tracking-[.15em] mx-auto pb-12 md:pb-36'>
         <div className='flex flex-col md:flex-row justify-between items-center gap-12'>
           <div className='whats-included w-full px-6 order-2'>
-            <h2 className='text-3xl md:text-3xl lg:text-5xl text-center md:text-start font-bold '>
+            <h2 className='text-3xl md:text-4xl lg:text-5xl text-center md:text-start font-bold '>
               Whats <br /> Included
             </h2>
             <div className='body py-6 w-full'>
@@ -146,8 +146,8 @@ const products = () => {
           </div>
         </div>
       </div>
-      <div className='pricing max-w-[1400px] mx-auto pb-12 md:pb-24 lg:pb-36'>
-        <h2 className='text-3xl md:text-3xl lg:text-5xl font-bold pb-12 md:pb-24 text-center'>
+      <div className='pricing max-w-[1200px] mx-auto pb-12 md:pb-24 lg:pb-36'>
+        <h2 className='text-3xl md:text-4xl lg:text-5xl font-bold pb-12 md:pb-24 text-center'>
           The Perfect Prices <br />
           For The Perfect Moment
         </h2>
@@ -187,10 +187,10 @@ const products = () => {
             </LinkButton>
           </div>
         </div>
-        <div className='add-ons px-6 mx-auto md:pb-24 lg:pb-36'>
+        <div className='add-ons px-6 mx-auto md:pb-24'>
           <div className='flex items-center pb-12 md:pb-24 '>
             <hr className='flex-grow h-[2px] bg-gray-700' />
-            <span className='text-3xl md:text-3xl lg:text-5xl font-extrabold uppercase px-4 text-center'>
+            <span className='text-3xl md:text-4xl lg:text-5xl font-extrabold uppercase px-4 text-center'>
               Add ons
             </span>
             <hr className='flex-grow h-[2px] bg-gray-700' />
@@ -204,7 +204,7 @@ const products = () => {
       </div>
 
       <div className='faq mx-auto h-full py-12 md:pb-36 px-6 bg-gray-100'>
-        <div className='max-w-[1400px] w-full mx-auto'>
+        <div className='max-w-[1200px] w-full mx-auto'>
           <div className='flex flex-col md:flex-row'>
             <div className='w-full md:w-[40%] md:p-8 lg:p-24 text-3xl md:text-4xl'>
               Lets clarify <br />A Few Things

--- a/components/ADList.tsx
+++ b/components/ADList.tsx
@@ -12,7 +12,7 @@ const ADList = ({ img, heading }: MediaDataType, index: number) => {
   return (
     <>
         <div
-          className='max-w-[500px] max-h-[575px] w-full h-full mx-auto'
+          className='max-w-[400px] max-h-[575px] w-full h-full mx-auto'
           key={index}
         >
           <div className='w-full h-full flex flex-col justify-center items-center'>
@@ -23,11 +23,11 @@ const ADList = ({ img, heading }: MediaDataType, index: number) => {
                 height={0}
                 sizes='100vw'
                 alt={`${heading} image`}
-                className='w-[450px] h-[400px] object-cover object-top rounded-3xl mx-auto'
+                className='w-[400px] h-[400px] object-cover object-top rounded-3xl mx-auto'
               />
               <div className='absolute inset-0 bg-gradient-to-t from-gray-900 via-gray-900/40 rounded-3xl'></div>
 
-              <div className='absolute p-6 max-h-[150px] md:max-h-[175px] max-w-[400px] w-full h-full bottom-0 left-0 right-0 text-white'>
+              <div className='absolute p-6 max-h-[150px] md:max-w-[400px] w-full h-full bottom-0 left-0 right-0 text-white'>
                 <h2 className='font-extrabold text-lg md:text-2xl py-2 uppercase'>
                   {heading}
                 </h2>


### PR DESCRIPTION
## Issue Overview:
The max width of the content needs to be changed to 1200px and the ad component text section needs to be fixed.

Issue: #42 

#### What is the context for the changes? Are there any?
These changes were made to improve the experience for users with smaller laptop screens.

## Changes made:
#### Include a list that briefly describes what changes you made in this PR.
- Changed the max width from 1400px to 1200px for the content sections
- Fixed the flow of the text by adjusting the width of the div and text div section
- Changed the headers text sizes to match
- Fix the padding on the product page -- above FAQ section

## Rationale behind the change:
#### Why did you choose to make these changes? Were there any trade-offs you had to consider?
These changes were made to improve the experience for users with smaller laptop screens.

## Test plan:
#### How did you confirm these changes were safe to ship to production?
Changes were tested in localhost using the 13in macbook pro dimensions to confirm no breaking changes.

## Screenshot (optional):
N/A 

## Quality check:
#### Do your changes follow best practices (SOLID)?
Yes

#### Are there any console.logs, unused code, or debuggers?
No.

#### Reread what you filled out and make sure it makes sense. Any extra context?
Yes.
